### PR TITLE
fixbug-阿里云盘部分资源剧集顺序显示混乱

### DIFF
--- a/app/src/main/java/com/github/catvod/ali/API.java
+++ b/app/src/main/java/com/github/catvod/ali/API.java
@@ -279,6 +279,7 @@ public class API {
         List<Item> files = new ArrayList<>();
         List<Item> subs = new ArrayList<>();
         listFiles(new Item(getParentFileId(fileId, object)), files, subs);
+        Collections.sort(files);
         List<String> playFrom = Arrays.asList("原畫", "普畫");
         List<String> episode = new ArrayList<>();
         List<String> playUrl = new ArrayList<>();

--- a/app/src/main/java/com/github/catvod/bean/ali/Item.java
+++ b/app/src/main/java/com/github/catvod/bean/ali/Item.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class Item {
+public class Item implements Comparable<Item> {
 
     @SerializedName("items")
     private List<Item> items;
@@ -84,5 +84,10 @@ public class Item {
 
     public String getDisplayName() {
         return TextUtils.join(" ", Arrays.asList(getParent(), getName(), getSize())).trim();
+    }
+    
+    @Override
+    public int compareTo(Item item) {
+        return this.getName().compareTo(item.getName());
     }
 }


### PR DESCRIPTION
阿里云盘部分资源剧集顺序显示混乱，以下以玩偶哥哥搜索出的资源展示为例截图

修复前截图：
![1](https://github.com/FongMi/CatVodSpider/assets/107969766/2875fd51-8081-43b9-b9eb-4171c99f56ad)
![2](https://github.com/FongMi/CatVodSpider/assets/107969766/888cc27d-bd22-4082-9420-5d9b40c1ad34)

修复后截图：
![3](https://github.com/FongMi/CatVodSpider/assets/107969766/0ccf44da-f248-405e-93aa-4b986996b29b)
![4](https://github.com/FongMi/CatVodSpider/assets/107969766/6d47be30-c83b-46ba-9678-07cf13971d1c)

