### PR TITLE
修复wogg部分资源不能播放问题

### DIFF
--- a/app/src/main/java/com/github/catvod/spider/Wogg.java
+++ b/app/src/main/java/com/github/catvod/spider/Wogg.java
@@ -103,6 +103,9 @@ public class Wogg extends Ali {
         item.setTypeName(String.join(",", doc.select(".video-info-header div.tag-link a").eachText()));
 
         List<String> shareLinks = doc.select(".module-row-text").eachAttr("data-clipboard-text");
+        for (int i = 0; i < shareLinks.size(); i++) {
+            shareLinks.set(i, shareLinks.get(i).trim());
+        }
         item.setVodPlayFrom(super.detailContentVodPlayFrom(shareLinks));
         item.setVodPlayUrl(super.detailContentVodPlayUrl(shareLinks));
 


### PR DESCRIPTION
因为wogg链接的部分地址有空白符号，所以会导致获取视频失败的问题，现已修复问题！